### PR TITLE
feat: add authorization header via prepareHeaders in baseApi 

### DIFF
--- a/src/shared/api/baseApi.ts
+++ b/src/shared/api/baseApi.ts
@@ -1,10 +1,22 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { RootState } from '@/app/store'
 
 export const baseApi = createApi({
   reducerPath: 'api',
   baseQuery: fetchBaseQuery({
     baseUrl: 'https://pickandstore.com/api/v1',
     credentials: 'include',
+    prepareHeaders: (headers, { getState }) => {
+      // you can take accessToken from localStorage/sessionStorage/RTK
+      const token = (getState() as RootState).auth.accessToken
+
+      // If we have a token set in state, let's assume that we should be passing it.
+      if (token) {
+        headers.set('authorization', `Bearer ${token}`)
+      }
+
+      return headers
+    },
   }),
   endpoints: () => ({}),
 })


### PR DESCRIPTION
Configured prepareHeaders inside baseApi to automatically attach the Authorization header if an accessToken exists in Redux state. This enables secure API requests using Bearer tokens with RTK Query.